### PR TITLE
Temporary support for github oauth token

### DIFF
--- a/src/main/java/io/meterian/jenkins/glue/MeterianPlugin.java
+++ b/src/main/java/io/meterian/jenkins/glue/MeterianPlugin.java
@@ -74,6 +74,8 @@ public class MeterianPlugin extends Builder {
         private String token;
         private String jvmArgs;
         
+        private String githubToken;
+        
         public Configuration() {
             load();
         }
@@ -93,9 +95,10 @@ public class MeterianPlugin extends Builder {
             url = computeFinalUrl(formData.getString("url"));
             token = computeFinalToken(formData.getString("token"));
             jvmArgs = parseEmpty(formData.getString("jvmArgs"), "");
+            githubToken = parseEmpty(formData.getString("githubToken"), "");
             
             save();
-            log.info("Stored configuration \nurl: [{}]\njvm: [{}]\ntoken: [{}]", url, jvmArgs, mask(token));
+            log.info("Stored configuration \nurl: [{}]\njvm: [{}]\ntoken: [{}]\ngithubToken: [{}]", url, jvmArgs, mask(token), mask(githubToken));
 
             return super.configure(req, formData);
         }
@@ -117,6 +120,10 @@ public class MeterianPlugin extends Builder {
 
         public String getToken() {
             return token;
+        }
+
+        public String getGithubToken() {
+            return githubToken;
         }
 
         public String getMeterianBaseUrl() {

--- a/src/main/resources/io/meterian/jenkins/glue/MeterianPlugin/global.jelly
+++ b/src/main/resources/io/meterian/jenkins/glue/MeterianPlugin/global.jelly
@@ -13,5 +13,9 @@
     <f:validateButton
        title="${%Test Connection}" progress="${%Testing...}"
        method="testConnection" with="url,token" />
+	<f:entry title="GitHub OAUTH token" field="githubToken" description="Enter a valid GitHub OAUTH token associated to your organisation or repository">
+      <f:textbox />
+    </f:entry>
+       
   </f:section>
 </j:jelly>

--- a/src/main/resources/io/meterian/jenkins/glue/MeterianPlugin/help-githubToken.html
+++ b/src/main/resources/io/meterian/jenkins/glue/MeterianPlugin/help-githubToken.html
@@ -1,0 +1,4 @@
+<div>
+    Specifies a valid OAUTH token for GitHub access. You can create a token from  
+    <a href="https://github.com/settings/tokens/new?scopes=repo,public_repo&description=Meterian+Access" target="_blank">GitHub</a>
+</div>


### PR DESCRIPTION
This provides an extra field, persisted by the plugin, in order to store the Gihub oauth token (until we do the proper integration wiith the github oauth plugin)