### PR TITLE
Meterian client runner test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,6 @@ jobs:
       
       - store_test_results: 
           path: target/surefire-reports
-      
+
+      - store_artifacts:
+          path: target/jacoco-reports

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ hs_err_pid*
 
 # maven, jenkins, meterian
 target
-work
+work*/
 *.fix
 *~
 
@@ -35,3 +35,4 @@ work
 
 .idea/
 meterian-plugin.iml
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ mvn test
 ### Specific tests
 
 ```bash
-mvn test -Dtest=MeterianClientRunnerTest
+mvn test -Dtest=MeterianClientTest
 ```
 
 ## Jenkins job types

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # jenkins-plugin
+
 The official Meterian plugin for Jenkins.
 
 This has not been published yet, but you can have a look at the code and snoop around. This plugin is expected to work in classic jobs and pipelines (Jenkinsfile) with the ability to include the analysis as part of your build process, as it should be.
@@ -7,9 +8,116 @@ The integration that we are building first, also in light that nobody did that b
 
 More to be written here after the plugin is launched :)
 
+
+## Build
+
+Build the project with the below command from inside the project root folder:
+
+```bash
+./bin/build.sh
+```
+
+Note: this runs the unit/integration tests which is part of the project and can take a bit of time.
+
+Tests it runs:
+
+Running InjectedTest:
+
+- InjectedTest
+- SimpleFileCompareTest
+- ClientDownloaderTest
+
+Look in the `target` folder for all the generate artifacts, you will find `meterian-plugin.jar` among others. 
+
+## Run
+
+Run the project with the below command from inside the project root folder:
+
+```bash
+./bin/run.sh
+```
+
+This kicks off a full-fledged Jenkins instance and can be access via http://0.0.0.0:8080/jenkins/ or http://localhost:8080/jenkins/ or http://127.0.0.1:8080/jenkins/.
+
+One or more jobs can be executed via this console. When these jobs are executed, and depending on the type of job, the Meterian Jenkins plugin configured with each of the jobs is triggered and the respective actions are executed.
+
+## Run Tests 
+
+### All tests
+
+```bash
+mvn test
+```
+
+### Specific tests
+
+```bash
+mvn test -Dtest=MeterianClientRunnerTest
+```
+
+## Jenkins job types
+
+### SimplePipeline
+
+Builds a single branch using the Pipeline facility via the `jenkinsfile` script.
+
+Technical detail: flows through the `MeterianPlugin` class and is handled by `SimpleOrFreeStyleExecutor`.
+
+### MultiPipeline
+
+Builds multiple branches concurrently, using the Pipeline facility via the `jenkinsfile` script.
+
+Technical detail: flows through the `MeterianStep` class and is handled by `StandardExecutor`.
+
+### FreeStyle
+
+Builds a single branch but does not give the facility to specific Jenkins config via the `jenkinsfile`.
+
+Technical detail: flows through the `MeterianPlugin` class and is handled by `SimpleOrFreeStyleExecutor`.
+
+## Meterian features
+
+The below features can be used across the above Jenkins job types. 
+
+### Only report
+
+Default behaviour no client args required.
+
+This option does the default task of scanning the project and reporting the vulnerabilities, if present, and recommended fixes but does not apply them.
+
+### Autofix (report and create Pull Request)
+
+Using the `--autofix` client arg option (Go to Jenkins > Configure > Meterian for the field Client JVM args).
+
+This option does the task of scanning the project and reporting the vulnerabilities, if present, and also applying the fix to the respective branch and creating a pull request to the repository.
+
+Ensure your GitHub OAuth token to your Organisation and Repo has been added to the Meterian configuration settings under Jenkins > Configure > Meterian. Enter your GitHub OAuth token in the field **GitHub OA UTH token**. If this field is empty or incorrect appropriate error messages are displayed in the Jenkins logger (console).
+
+#### Running Meterian client from CLI
+
+The below command should do it, provided the plugin has already downloaded the client:
+
+```bash
+java -jar ${HOME}/.meterian/meterian-cli.jar [meterian args]
+```
+
+[meterian args] - one or more args for additional features i.e. `--interactive=false` or `--autofix`
+
+On the first run, it will authorise you, so please ensure you have an account on https://www.meterian.com.
+
+_Note: the Meterian client is automatically downloaded by the plugin when it detects the absence of it and is saved in the `${HOME}/.meterian` folder._
+
 #### Additional information and sources about writing plugins for Jenkins
-https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial
-https://wiki.jenkins.io/display/JENKINS/Create+a+new+Plugin+with+a+custom+build+Step
+
+- https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial
+- https://wiki.jenkins.io/display/JENKINS/Create+a+new+Plugin+with+a+custom+build+Step
+
+See https://stackoverflow.com/questions/43690435/failure-to-find-org-jenkins-ci-pluginspluginpom2-11-in-https-repo-maven-apa on how to avoid the below warning message:
+
+```bash
+[WARNING] The POM for org.jenkins-ci.tools:maven-hpi-plugin:jar:2.7 is missing, no dependency information available
+[WARNING] Failed to build parent project for io.jenkins.plugins:meterian-plugin:hpi:0.1-SNAPSHOT
+```
 
 #### Build status
 [![CircleCI](https://circleci.com/gh/MeterianHQ/jenkins-plugin.svg?style=svg)](https://circleci.com/gh/MeterianHQ/jenkins-plugin)

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,1 +1,2 @@
-mvn -Djna.nosys=true clean package
+mvn mvn -T1C -am \
+        -Djna.nosys=true clean package

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,1 +1,6 @@
 mvn -Djna.nosys=true clean hpi:run
+
+# ~~~~ Startup time (approx.) ~~~~
+# real    1m3.438s
+# user    1m53.865s
+# sys 0m12.465s

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,20 @@
 			<artifactId>org.eclipse.egit.github.core</artifactId>
 			<version>2.1.5</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>hamcrest-core</artifactId>
+					<groupId>org.hamcrest</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
 
     <build>
@@ -149,6 +163,45 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.3</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+
+							<dataFile>target/jacoco.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>target/jacoco-reports</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<systemPropertyVariables>
+						<jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
             <!--
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>

--- a/src/main/java/com/meterian/common/system/Shell.java
+++ b/src/main/java/com/meterian/common/system/Shell.java
@@ -11,8 +11,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import io.meterian.jenkins.core.Meterian;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
@@ -102,23 +100,6 @@ public class Shell {
     }
 
     public static class Task {
-        public static void main(String[] args) throws IOException {
-            String[] commands = new String[]{
-                    "java",
-                    "-Dcli.param.folder=/path/to/workspace/TestMeterianPlugin-Freestyle-autofix",
-                    "-jar",
-                    "/path/to/.meterian/meterian-cli.jar", "--interactive=false"};
-
-            Meterian.Result result = new Meterian.Result();
-            Shell shell = new Shell();
-
-            Task task = shell.exec(commands, new Options());
-            task.waitFor();
-            result.exitCode = task.exitValue();
-
-            System.out.println(result.exitCode);
-        }
-
         public static final long DEFAULT_TIMEOUT_IN_SECONDS = 60L*5L;
 
         private final Process process;

--- a/src/main/java/io/meterian/jenkins/autofixfeature/github/LocalGitHubClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/github/LocalGitHubClient.java
@@ -19,8 +19,8 @@ public class LocalGitHubClient {
 
     static final Logger log = LoggerFactory.getLogger(LocalGitHubClient.class);
 
-    private static final String GITHUB_TOKEN_ABSENT_WARNING =
-            "[meterian] Warning: GITHUB_TOKEN has not been set in the config (please check meterian settings in " +
+    private static final String METERIAN_GITHUB_TOKEN_ABSENT_WARNING =
+            "[meterian] Warning: METERIAN_GITHUB_TOKEN has not been set in the config (please check meterian settings in " +
                     "Manage Jenkins), cannot create pull request.";
     private static final String PULL_REQUEST_ALREADY_EXISTS_WARNING =
             "[meterian] Warning: Pull request already exists for this branch, no new pull request will be created. " +
@@ -43,7 +43,7 @@ public class LocalGitHubClient {
             }
         });
         new LocalGitHubClient(
-                System.getenv("GITHUB_TOKEN"),
+                System.getenv("METERIAN_GITHUB_TOKEN"),
                 "MeterianHQ",
                 "MeterianHQ/autofix-sample-maven-upgrade",
                 noOpStream).createPullRequest("fixed-by-meterian-29c4d26");
@@ -58,8 +58,8 @@ public class LocalGitHubClient {
         this.jenkinsLogger = jenkinsLogger;
 
         if (gitHubToken == null || gitHubToken.isEmpty()) {
-            log.warn(GITHUB_TOKEN_ABSENT_WARNING);
-            jenkinsLogger.println(GITHUB_TOKEN_ABSENT_WARNING);
+            log.warn(METERIAN_GITHUB_TOKEN_ABSENT_WARNING);
+            jenkinsLogger.println(METERIAN_GITHUB_TOKEN_ABSENT_WARNING);
             return;
         }
 

--- a/src/main/java/io/meterian/jenkins/glue/MeterianPlugin.java
+++ b/src/main/java/io/meterian/jenkins/glue/MeterianPlugin.java
@@ -105,6 +105,15 @@ public class MeterianPlugin extends Builder {
             load();
         }
 
+        public Configuration(String url, String token, String jvmArgs, String githubToken) {
+            this.url = url;
+            this.token = token;
+            this.jvmArgs = jvmArgs;
+            this.githubToken = githubToken;
+
+            log.info("Read configuration \nurl: [{}]\njvm: [{}]\ntoken: [{}]\ngithubToken: [{}]", url, jvmArgs, mask(token), mask(githubToken));
+        }
+
         @Override
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             return true | FreeStyleProject.class.isAssignableFrom(jobType);

--- a/src/test/java/integration_tests/MeterianClientRunnerTest.java
+++ b/src/test/java/integration_tests/MeterianClientRunnerTest.java
@@ -2,46 +2,84 @@ package integration_tests;
 
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.http.client.HttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import com.meterian.common.system.OS;
+import com.meterian.common.system.Shell;
 import io.meterian.jenkins.core.Meterian;
 import io.meterian.jenkins.glue.MeterianPlugin;
 import io.meterian.jenkins.io.ClientDownloader;
 import io.meterian.jenkins.io.HttpClientFactory;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.http.client.HttpClient;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
 
 import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 public class MeterianClientRunnerTest {
 
-    private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
     private static final String BASE_URL = "https://www.meterian.com";
+    private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
 
-    private String jenkinsProjectName = "TestMeterianPlugin-Freestyle-autofix";
+    private static final String NO_JVM_ARGS = "";
+
+    private String gitRepoWorkingFolder;
+
+    @Before
+    public void setup() throws IOException {
+        String gitRepoRootFolder = Paths.get(CURRENT_WORKING_DIR, "target/github-repo/").toString();
+        FileUtils.deleteDirectory(new File(gitRepoRootFolder));
+
+        new File(gitRepoRootFolder).mkdir();
+
+        gitRepoWorkingFolder = performCloneGitRepo(gitRepoRootFolder);
+    }
+
+    private String performCloneGitRepo(String gitRepoRootFolder) throws IOException {
+        String githubProjectName = "autofix-sample-maven-upgrade";
+        String[] gitCloneRepoCommand = new String[] {
+          "git",
+          "clone",
+          "https://github.com/MeterianHQ/" + githubProjectName + ".git"
+        };
+
+        Shell.Options options = new Shell.Options().
+                onDirectory(new File(gitRepoRootFolder));
+        Shell.Task task = new Shell().exec(
+                gitCloneRepoCommand,
+                options
+        );
+        task.waitFor();
+
+        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
+                task.exitValue(), task.exitValue(), is(equalTo(0)));
+
+        return Paths.get(gitRepoRootFolder, githubProjectName).toString();
+    }
 
     @Test
-//    @Ignore("Runs only in an environment with the Jenkins hpi and Meterian setup in place")
-    public void givenConfiguration_whenMeterianClientIsRun_thenItShouldNotThrowException()
-            throws IOException, ParserConfigurationException, SAXException {
-        EnvVars environment = getEnvironment(jenkinsProjectName);
+    public void givenConfiguration_whenMeterianClientIsRun_thenItShouldNotThrowException() throws IOException {
+        // Given: we are setup to run the meterian client against a repo that has vulnerabilities
+
+        EnvVars environment = getEnvironment();
+        String meterianAPIToken = environment.get("METERIAN_API_TOKEN");
+        assertThat("METERIAN_API_TOKEN has not been set, cannot run test without a valid value", meterianAPIToken, notNullValue());
+        String meterianGithubToken = environment.get("METERIAN_GITHUB_TOKEN");
+        assertThat("METERIAN_GITHUB_TOKEN has not been set, cannot run test without a valid value", meterianGithubToken, notNullValue());
+
         MeterianPlugin.Configuration configuration = new MeterianPlugin.Configuration(
                 BASE_URL,
-                environment.get("METERIAN_API_TOKEN"),
-                "", // jvmArgs
-                environment.get("METERIAN_GITHUB_TOKEN")
+                meterianAPIToken,
+                NO_JVM_ARGS,
+                meterianGithubToken
         );
 
         File logFile = File.createTempFile("jenkins-logger", Long.toString(System.nanoTime()));
@@ -49,21 +87,27 @@ public class MeterianClientRunnerTest {
 
         String args = "";
 
+        // When: the meterian client is run against the locally cloned git repo
         try {
             File clientJar = new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
             Meterian client = Meterian.build(configuration, environment, jenkinsLogger, args, clientJar);
             client.prepare("--interactive=false");
             client.run();
             jenkinsLogger.close();
-
-            String buildLogs = readBuildLogs(logFile.getPath());
-            assertThat(buildLogs, containsString("[meterian] Client successfully authorized"));
-            assertThat(buildLogs, containsString("[meterian] Meterian Client v"));
-            assertThat(buildLogs, containsString("[meterian] Project information:"));
-            assertThat(buildLogs, containsString("[meterian] JAVA scan -"));
         } catch (Exception ex) {
             fail("Should not have failed with the exception: " + ex.getMessage());
         }
+
+        // Then: we should be able to see the expecting output in the execution analysis output logs
+        String runAnalysisLogs = readBuildLogs(logFile.getPath());
+        assertThat(runAnalysisLogs, containsString("[meterian] Client successfully authorized"));
+        assertThat(runAnalysisLogs, containsString("[meterian] Meterian Client v"));
+        assertThat(runAnalysisLogs, containsString("[meterian] Project information:"));
+        assertThat(runAnalysisLogs, containsString("[meterian] JAVA scan -"));
+        assertThat(runAnalysisLogs, containsString("MeterianHQ/autofix-sample-maven-upgrade.git"));
+        assertThat(runAnalysisLogs, containsString("[meterian] Full report available at: "));
+        assertThat(runAnalysisLogs, containsString("[meterian] Build unsuccesful!"));
+        assertThat(runAnalysisLogs, containsString("[meterian] Failed checks: [security]"));
     }
 
     private String readBuildLogs(String pathToBuildLog) throws IOException {
@@ -104,28 +148,15 @@ public class MeterianClientRunnerTest {
             }});
     }
 
-    private EnvVars getEnvironment(String projectName) throws IOException, SAXException, ParserConfigurationException {
+    private EnvVars getEnvironment() {
         EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
         EnvVars environment = prop.getEnvVars();
-        environment.put("WORKSPACE", getPathToWorkspace(projectName));
 
-        String pathToMeterianPluginConfig = CURRENT_WORKING_DIR + "/work/io.meterian.jenkins.glue.MeterianPlugin.xml";
-        Document xmlDocument = loadXMLFile(pathToMeterianPluginConfig);
-        environment.put("METERIAN_API_TOKEN", xmlDocument.getElementsByTagName("token").item(0).getTextContent());
-        environment.put("METERIAN_GITHUB_TOKEN", xmlDocument.getElementsByTagName("githubToken").item(0).getTextContent());
+        Map<String, String> localEnvironment = new OS().getenv();
+        for (String envKey: localEnvironment.keySet()) {
+            environment.put(envKey, localEnvironment.get(envKey));
+        }
+        environment.put("WORKSPACE", gitRepoWorkingFolder);
         return environment;
-    }
-
-    private Document loadXMLFile(String filename) throws ParserConfigurationException, IOException, SAXException {
-        File file = new File(filename);
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
-        Document document = db.parse(file);
-        document.getDocumentElement().normalize();
-        return document;
-    }
-
-    private String getPathToWorkspace(String projectName) {
-        return String.format("%s/work/workspace/%s", CURRENT_WORKING_DIR, projectName);
     }
 }

--- a/src/test/java/integration_tests/MeterianClientRunnerTest.java
+++ b/src/test/java/integration_tests/MeterianClientRunnerTest.java
@@ -1,0 +1,112 @@
+package integration_tests;
+
+import hudson.EnvVars;
+import hudson.model.Descriptor;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import io.meterian.jenkins.core.Meterian;
+import io.meterian.jenkins.glue.MeterianPlugin;
+import io.meterian.jenkins.io.ClientDownloader;
+import io.meterian.jenkins.io.HttpClientFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.http.client.HttpClient;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class MeterianClientRunnerTest {
+
+    private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
+    private static final String BASE_URL = "https://www.meterian.com";
+
+    private String jenkinsProjectName = "TestMeterianPlugin-Freestyle-autofix";
+
+    @Test
+//    @Ignore("Under implementation")
+    public void givenConfiguration_whenMeterianClientIsRun_thenItShouldNotThrowException()
+            throws IOException, ParserConfigurationException, SAXException, Descriptor.FormException {
+        String pathToMeterianPluginConfig = CURRENT_WORKING_DIR + "/work/io.meterian.jenkins.glue.MeterianPlugin.xml";
+
+        MeterianPlugin.Configuration configuration = new MeterianPlugin.Configuration(pathToMeterianPluginConfig);
+        EnvVars environment = getEnvironment(jenkinsProjectName);
+
+        File logFile = File.createTempFile("jenkins-logger", Long.toString(System.nanoTime()));
+        PrintStream jenkinsLogger = new PrintStream(logFile);
+
+        String args = "";
+
+        try {
+            File clientJar = new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+            Meterian client = Meterian.build(configuration, environment, jenkinsLogger, args, clientJar);
+            client.prepare("--interactive=false");
+            client.run();
+            jenkinsLogger.close();
+
+            String buildLogs = readBuildLogs(logFile.getPath());
+            assertThat(buildLogs, containsString("[meterian] Client successfully authorized"));
+            assertThat(buildLogs, containsString("[meterian] Meterian Client v"));
+            assertThat(buildLogs, containsString("[meterian] Project information:"));
+            assertThat(buildLogs, containsString("[meterian] JAVA scan -"));
+        } catch (Exception ex) {
+            fail("Should not have failed with the exception: " + ex.getMessage());
+        }
+    }
+
+    private String readBuildLogs(String pathToBuildLog) throws IOException {
+        File buildLogFile = new File(pathToBuildLog);
+        return FileUtils.readFileToString(buildLogFile);
+    }
+
+    private PrintStream nullPrintStream() {
+        return new PrintStream(new NullOutputStream());
+    }
+
+    private static HttpClient newHttpClient() {
+        return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
+            @Override
+            public int getHttpConnectTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpSocketTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpMaxTotalConnections() {
+                return 100;
+            }
+
+            @Override
+            public int getHttpMaxDefaultConnectionsPerRoute() {
+                return 100;
+            }
+
+            @Override
+            public String getHttpUserAgent() {
+                // TODO Auto-generated method stub
+                return null;
+            }});
+    }
+
+    private EnvVars getEnvironment(String projectName) {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars environment = prop.getEnvVars();
+        environment.put("WORKSPACE", getPathToWorkspace(projectName));
+        return environment;
+    }
+
+    private String getPathToWorkspace(String projectName) {
+        return String.format("%s/work/workspace/%s", CURRENT_WORKING_DIR, projectName);
+    }
+}

--- a/src/test/java/integration_tests/MeterianClientTest.java
+++ b/src/test/java/integration_tests/MeterianClientTest.java
@@ -24,7 +24,7 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
-public class MeterianClientRunnerTest {
+public class MeterianClientTest {
 
     private static final String BASE_URL = "https://www.meterian.com";
     private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
@@ -41,28 +41,6 @@ public class MeterianClientRunnerTest {
         new File(gitRepoRootFolder).mkdir();
 
         gitRepoWorkingFolder = performCloneGitRepo(gitRepoRootFolder);
-    }
-
-    private String performCloneGitRepo(String gitRepoRootFolder) throws IOException {
-        String githubProjectName = "autofix-sample-maven-upgrade";
-        String[] gitCloneRepoCommand = new String[] {
-          "git",
-          "clone",
-          "https://github.com/MeterianHQ/" + githubProjectName + ".git"
-        };
-
-        Shell.Options options = new Shell.Options().
-                onDirectory(new File(gitRepoRootFolder));
-        Shell.Task task = new Shell().exec(
-                gitCloneRepoCommand,
-                options
-        );
-        task.waitFor();
-
-        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
-                task.exitValue(), task.exitValue(), is(equalTo(0)));
-
-        return Paths.get(gitRepoRootFolder, githubProjectName).toString();
     }
 
     @Test
@@ -99,7 +77,7 @@ public class MeterianClientRunnerTest {
         }
 
         // Then: we should be able to see the expecting output in the execution analysis output logs
-        String runAnalysisLogs = readBuildLogs(logFile.getPath());
+        String runAnalysisLogs = readRunAnalysisLogs(logFile.getPath());
         assertThat(runAnalysisLogs, containsString("[meterian] Client successfully authorized"));
         assertThat(runAnalysisLogs, containsString("[meterian] Meterian Client v"));
         assertThat(runAnalysisLogs, containsString("[meterian] Project information:"));
@@ -110,9 +88,31 @@ public class MeterianClientRunnerTest {
         assertThat(runAnalysisLogs, containsString("[meterian] Failed checks: [security]"));
     }
 
-    private String readBuildLogs(String pathToBuildLog) throws IOException {
-        File buildLogFile = new File(pathToBuildLog);
-        return FileUtils.readFileToString(buildLogFile);
+    private String performCloneGitRepo(String gitRepoRootFolder) throws IOException {
+        String githubProjectName = "autofix-sample-maven-upgrade";
+        String[] gitCloneRepoCommand = new String[] {
+                "git",
+                "clone",
+                "https://github.com/MeterianHQ/" + githubProjectName + ".git"
+        };
+
+        Shell.Options options = new Shell.Options().
+                onDirectory(new File(gitRepoRootFolder));
+        Shell.Task task = new Shell().exec(
+                gitCloneRepoCommand,
+                options
+        );
+        task.waitFor();
+
+        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
+                task.exitValue(), task.exitValue(), is(equalTo(0)));
+
+        return Paths.get(gitRepoRootFolder, githubProjectName).toString();
+    }
+
+    private String readRunAnalysisLogs(String pathToLog) throws IOException {
+        File logFile = new File(pathToLog);
+        return FileUtils.readFileToString(logFile);
     }
 
     private PrintStream nullPrintStream() {


### PR DESCRIPTION
Run a the Meterian client runner test in a remote / isolated environment
- test covers a basic flow from setting up client to running it against a vulnerable project and then checking the results of the analysis are as expected (meterian client takes no additional options as params)
- will need authorisation from meterian to allow running analysis against project (plan restrictions apply)
- all basic settings are in place for the meterian client to run
- the necessary assertions are made to verify we have a running client which reports on a vulnerable project 
- added docs to README to describe and clarify usage
- added code coverage generation ability (also amended CircleCI config to store this per build)
- duplications in implementation will be moved to common classes during subsequent tests
- manual tests performed via Jenkins HPI and results are as expected (match to previous runs)

Happy to receive constructive feedback on the changes. Some changes were needed to be able to bring the client under test, although these were mere additions of new constructors or additional methods without impacting original functionality.