### PR TITLE
Meterian client autofix feature test (1/3)

### DIFF
--- a/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
@@ -34,16 +34,13 @@ public class AutoFixFeature {
 
     public void execute() {
         try {
-            if (localGitClient.currentBranchWasNotCreatedByMeterianClient() &&
-                    localGitClient.otherMeterianLocalBranchesDoNotExist()) {
-                log.info(localGitClient.getCurrentBranch() + " does not exist in local repo");
-                clientRunner.execute();
+            clientRunner.execute();
+
+            if (localGitClient.hasChanges()) {
                 localGitClient.applyCommitsToLocalRepo();
             } else {
-                String branchAlreadyExistsWarning =
-                        String.format(LOCAL_BRANCH_ALREADY_EXISTS_WARNING, localGitClient.getCurrentBranch());
-                log.warn(branchAlreadyExistsWarning);
-                jenkinsLogger.println(branchAlreadyExistsWarning);
+                log.warn(LocalGitClient.NO_CHANGES_FOUND_WARNING);
+                jenkinsLogger.println(LocalGitClient.NO_CHANGES_FOUND_WARNING);
             }
 
             localGitClient.pushBranchToRemoteRepo();

--- a/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
@@ -27,8 +27,8 @@ public class LocalGitClient {
     private static final String REMOTE_BRANCH_ALREADY_EXISTS_WARNING = "[meterian] Warning: %s already exists in the remote repo, skipping the remote branch creation process.";
     private static final String FIXED_BY_METERIAN = "fixed-by-meterian";
 
-    private static final String METERIAN_BOT = "meterian-bot";
-    private static final String METERIAN_BOT_EMAIL = "bot.github@meterian.io";
+    public static final String METERIAN_BOT = "meterian-bot";
+    public static final String METERIAN_BOT_EMAIL = "bot.github@meterian.io";
     private static final String METERIAN_COMMIT_MESSAGE = "Fixes applied via " + METERIAN_BOT;
 
     private final Git git;

--- a/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
@@ -15,17 +15,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class LocalGitClient {
 
     static final Logger log = LoggerFactory.getLogger(LocalGitClient.class);
 
-    private static final String NO_CHANGES_FOUND_WARNING = "No changes found (no fixed generated), no branch to push to the remote repo.";
+    public static final String NO_CHANGES_FOUND_WARNING = "No changes found (no fixed generated), no branch to push to the remote repo.";
+
     private static final String REMOTE_BRANCH_ALREADY_EXISTS_WARNING = "[meterian] Warning: %s already exists in the remote repo, skipping the remote branch creation process.";
     private static final String FIXED_BY_METERIAN = "fixed-by-meterian";
 
@@ -36,39 +34,6 @@ public class LocalGitClient {
     private final Git git;
     private PrintStream jenkinsLogger;
     private String currentBranch;
-
-    public static void main(String[] args) throws GitAPIException, IOException {
-//        String pathToRepo = "/path/to/meterian/jenkins-plugin/work/workspace/TestMeterianSimplePipeline-autofix";
-        String pathToRepo = "path/to/meterian/jenkins-plugin/work/workspace/ultiPipeline-autofix_master-R7BPEVOKUIKKVF72USMTYF2U6Z2VP6KEXA3A7LEZGIUW4BAN6PLA";
-
-        PrintStream noOpStream = new PrintStream(new OutputStream() {
-            public void write(int b) {
-                // NO-OP
-            }
-        });
-
-        LocalGitClient localGitClient = new LocalGitClient(pathToRepo, noOpStream);
-
-        if (localGitClient.hasChanges()) {
-            if (localGitClient.currentBranchWasNotCreatedByMeterianClient() &&
-                    localGitClient.otherMeterianLocalBranchesDoNotExist()) {
-                System.out.println(localGitClient.createBranch());
-
-                Set<String> unCommittedFiles = localGitClient.listOfChanges();
-                System.out.println(unCommittedFiles);
-
-                System.out.println(localGitClient.addChangedFileToBranch(unCommittedFiles));
-                System.out.println(localGitClient.commitChanges(
-                            METERIAN_BOT,
-                            METERIAN_BOT,
-                            METERIAN_BOT_EMAIL,
-                            METERIAN_COMMIT_MESSAGE
-                        )
-                );
-            }
-            localGitClient.pushBranchToRemoteRepo();
-        }
-    }
 
     public LocalGitClient(String pathToRepo, PrintStream jenkinsLogger) {
         this.jenkinsLogger = jenkinsLogger;
@@ -93,7 +58,6 @@ public class LocalGitClient {
     }
 
     public void applyCommitsToLocalRepo() throws GitAPIException, IOException {
-        if (hasChanges()) {
             createBranch();
 
             Set<String> unCommittedFiles = listOfChanges();
@@ -107,10 +71,6 @@ public class LocalGitClient {
                     METERIAN_COMMIT_MESSAGE);
 
             log.info("Finished committing changes to branch " + currentBranch);
-        } else {
-            log.warn(NO_CHANGES_FOUND_WARNING);
-            jenkinsLogger.println(NO_CHANGES_FOUND_WARNING);
-        }
     }
 
     public boolean otherMeterianLocalBranchesDoNotExist() throws GitAPIException {
@@ -125,8 +85,8 @@ public class LocalGitClient {
 
     public String getOrgOrUsername() throws GitAPIException {
         String[] fullRepoName = getRepositoryName().split("/");
-        if ((fullRepoName != null) && (fullRepoName.length > 0)) {
-            return fullRepoName[0];
+        if (fullRepoName.length > 0) {
+            return fullRepoName[0].isEmpty() ? fullRepoName[1] : fullRepoName[0];
         }
 
         return "";
@@ -139,23 +99,31 @@ public class LocalGitClient {
     }
 
     public void pushBranchToRemoteRepo() throws GitAPIException {
-        log.debug("Checking if current branch was created by Meterian");
-        if (currentBranchWasCreatedByMeterianClient()) {
-            log.info(String.format("Checking if the branch %s to be created already exists in remote repo", currentBranch));
-            git.fetch()
-                    .setRemoveDeletedRefs(true)
-                    .call();
-            if (meterianRemoteBranchDoesNotExists()) {
-                log.info(String.format("Branch %s does not exist in remote repo, started pushing branch", currentBranch));
-                git.push().call();
-                log.info("Finished pushing branch to remote repo");
+        try {
+            log.debug("Checking if current branch was created by Meterian");
+            if (currentBranchWasCreatedByMeterianClient()) {
+                log.info(String.format("Checking if the branch %s to be created already exists in remote repo", currentBranch));
+                git.fetch()
+                        .setRemoveDeletedRefs(true)
+                        .call();
+                if (meterianRemoteBranchDoesNotExists()) {
+                    log.info(String.format("Branch %s does not exist in remote repo, started pushing branch", currentBranch));
+                    git.push().call();
+                    log.info("Finished pushing branch to remote repo");
+                } else {
+                    String branchAlreadyExistsWarning = String.format(REMOTE_BRANCH_ALREADY_EXISTS_WARNING, currentBranch);
+                    log.warn(branchAlreadyExistsWarning);
+                    jenkinsLogger.println(branchAlreadyExistsWarning);
+                }
             } else {
-                String branchAlreadyExistsWarning = String.format(REMOTE_BRANCH_ALREADY_EXISTS_WARNING, currentBranch);
-                log.warn(branchAlreadyExistsWarning);
-                jenkinsLogger.println(branchAlreadyExistsWarning);
+                log.debug("Current branch was not created by Meterian");
             }
-        } else {
-            log.debug("Current branch was not created by Meterian");
+        } catch (Exception ex) {
+            String couldNotPushDueToError = "Could not push branch " + currentBranch + " to remote repo due to error: " + ex.getMessage();
+            log.debug(couldNotPushDueToError);
+            jenkinsLogger.println(couldNotPushDueToError);
+
+            throw new RuntimeException(ex);
         }
     }
 
@@ -189,8 +157,9 @@ public class LocalGitClient {
 
     private boolean currentBranchWasCreatedByMeterianClient() throws GitAPIException {
         Iterable<RevCommit> logs = git.log().call();
-        if (logs.iterator().hasNext()) {
-            RevCommit currentCommit = logs.iterator().next();
+        Iterator<RevCommit> iterator = logs.iterator();
+        if (iterator.hasNext()) {
+            RevCommit currentCommit = iterator.next();
             PersonIdent author = currentCommit.getAuthorIdent();
             return author.getName().equalsIgnoreCase(METERIAN_BOT) &&
                     author.getEmailAddress().equalsIgnoreCase(METERIAN_BOT_EMAIL);
@@ -223,7 +192,7 @@ public class LocalGitClient {
                 .getModified();
     }
 
-    private boolean hasChanges() throws GitAPIException {
+    public boolean hasChanges() throws GitAPIException {
         return !git.status()
                 .call()
                 .isClean();

--- a/src/main/java/io/meterian/jenkins/autofixfeature/github/LocalGitHubClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/github/LocalGitHubClient.java
@@ -77,10 +77,12 @@ public class LocalGitHubClient {
                 Repository repository = getRepositoryFrom(orgOrUserName, repoName);
                 String title = "[meterian] Fix for vulnerable dependencies";
                 String body = "Dependencies in project configuration file has been fixed";
-                PullRequestMarker head = new PullRequestMarker().setLabel(
-                        String.format("%s:%s", orgOrUserName, branchName)
-                );
-                PullRequestMarker base = new PullRequestMarker().setLabel("master");
+                PullRequestMarker head = new PullRequestMarker()
+                        .setRef(branchName)
+                        .setLabel(String.format("%s:%s", orgOrUserName, branchName));
+                PullRequestMarker base = new PullRequestMarker()
+                                .setRef("master")
+                                .setLabel("master");
                 PullRequest pullRequest = new PullRequest()
                         .setTitle(title)
                         .setHead(head)

--- a/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -1,0 +1,183 @@
+package integration_tests;
+
+import com.meterian.common.system.OS;
+import com.meterian.common.system.Shell;
+import hudson.EnvVars;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import io.meterian.jenkins.autofixfeature.AutoFixFeature;
+import io.meterian.jenkins.autofixfeature.git.LocalGitClient;
+import io.meterian.jenkins.autofixfeature.github.LocalGitHubClient;
+import io.meterian.jenkins.core.Meterian;
+import io.meterian.jenkins.glue.MeterianPlugin;
+import io.meterian.jenkins.glue.clientrunners.MultiStageClientRunner;
+import io.meterian.jenkins.glue.executors.MeterianExecutor;
+import io.meterian.jenkins.glue.executors.StandardExecutor;
+import io.meterian.jenkins.io.ClientDownloader;
+import io.meterian.jenkins.io.HttpClientFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.http.client.HttpClient;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class MeterianClientAutofixFeatureTest {
+
+    private static final String BASE_URL = "https://www.meterian.com";
+    private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
+
+    private static final String NO_JVM_ARGS = "";
+
+    private String gitRepoWorkingFolder;
+
+    @Before
+    public void setup() throws IOException {
+        String gitRepoRootFolder = Paths.get(CURRENT_WORKING_DIR, "target/github-repo/").toString();
+        FileUtils.deleteDirectory(new File(gitRepoRootFolder));
+
+        new File(gitRepoRootFolder).mkdir();
+
+        gitRepoWorkingFolder = performCloneGitRepo(gitRepoRootFolder);
+    }
+
+    @Test
+    public void givenConfiguration_whenMeterianClientIsRunWithAutofixOption_thenItShouldReturnAnalysisReportAndFixThem() throws IOException, GitAPIException {
+        // Given: we are setup to run the meterian client against a repo that has vulnerabilities
+
+        EnvVars environment = getEnvironment();
+        String meterianAPIToken = environment.get("METERIAN_API_TOKEN");
+        assertThat("METERIAN_API_TOKEN has not been set, cannot run test without a valid value", meterianAPIToken, notNullValue());
+        String meterianGithubToken = environment.get("METERIAN_GITHUB_TOKEN");
+        assertThat("METERIAN_GITHUB_TOKEN has not been set, cannot run test without a valid value", meterianGithubToken, notNullValue());
+
+        MeterianPlugin.Configuration configuration = new MeterianPlugin.Configuration(
+                BASE_URL,
+                meterianAPIToken,
+                NO_JVM_ARGS,
+                meterianGithubToken
+        );
+
+        File logFile = File.createTempFile("jenkins-logger", Long.toString(System.nanoTime()));
+        PrintStream jenkinsLogger = new PrintStream(logFile);
+
+        String args = "";
+
+        // When: the meterian client is run against the locally cloned git repo with the autofix feature (--autofix) passed as a CLI arg
+        try {
+            File clientJar = new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+            Meterian client = Meterian.build(configuration, environment, jenkinsLogger, args, clientJar);
+
+            MultiStageClientRunner clientRunner =
+                    new MultiStageClientRunner(client, mock(StepContext.class), jenkinsLogger);
+
+            AutoFixFeature autoFixFeature = new AutoFixFeature(
+                    configuration,
+                    environment.get("WORKSPACE"),
+                    clientRunner,
+                    jenkinsLogger
+            );
+            MeterianExecutor executor = new StandardExecutor(mock(StepContext.class), clientRunner, autoFixFeature);
+
+            jenkinsLogger.close();
+
+
+        } catch (Exception ex) {
+            fail("Should not have failed with the exception: " + ex.getMessage());
+        }
+
+        // Then: we should be able to see the expected output in the execution analysis output logs and the
+        // reported vulnerabilities should be fixed, the changes committed to a branch and a pull request
+        // created onto the respective remote Github repository of the project
+        LocalGitClient gitClient = mock(LocalGitClient.class);
+        verify(gitClient).applyCommitsToLocalRepo();
+        verify(gitClient).pushBranchToRemoteRepo();
+
+        LocalGitHubClient localGitHubClient = mock(LocalGitHubClient.class);
+        verify(localGitHubClient).createPullRequest(anyString());
+    }
+
+    private String performCloneGitRepo(String gitRepoRootFolder) throws IOException {
+        String githubProjectName = "autofix-sample-maven-upgrade";
+        String[] gitCloneRepoCommand = new String[] {
+                "git",
+                "clone",
+                "https://github.com/MeterianHQ/" + githubProjectName + ".git"
+        };
+
+        Shell.Options options = new Shell.Options().
+                onDirectory(new File(gitRepoRootFolder));
+        Shell.Task task = new Shell().exec(
+                gitCloneRepoCommand,
+                options
+        );
+        task.waitFor();
+
+        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
+                task.exitValue(), task.exitValue(), is(equalTo(0)));
+
+        return Paths.get(gitRepoRootFolder, githubProjectName).toString();
+    }
+
+    private String readRunAnalysisLogs(String pathToLog) throws IOException {
+        File logFile = new File(pathToLog);
+        return FileUtils.readFileToString(logFile);
+    }
+
+    private PrintStream nullPrintStream() {
+        return new PrintStream(new NullOutputStream());
+    }
+
+    private static HttpClient newHttpClient() {
+        return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
+            @Override
+            public int getHttpConnectTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpSocketTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpMaxTotalConnections() {
+                return 100;
+            }
+
+            @Override
+            public int getHttpMaxDefaultConnectionsPerRoute() {
+                return 100;
+            }
+
+            @Override
+            public String getHttpUserAgent() {
+                // TODO Auto-generated method stub
+                return null;
+            }});
+    }
+
+    private EnvVars getEnvironment() {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars environment = prop.getEnvVars();
+
+        Map<String, String> localEnvironment = new OS().getenv();
+        for (String envKey: localEnvironment.keySet()) {
+            environment.put(envKey, localEnvironment.get(envKey));
+        }
+        environment.put("WORKSPACE", gitRepoWorkingFolder);
+        return environment;
+    }
+}

--- a/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -97,7 +97,7 @@ public class MeterianClientAutofixFeatureTest {
                     clientRunner,
                     jenkinsLogger
             );
-            MeterianExecutor executor = new StandardExecutor(mock(StepContext.class), clientRunner, autoFixFeature);
+            MeterianExecutor executor = new StandardExecutor(clientRunner, autoFixFeature);
             executor.run(client);
             jenkinsLogger.close();
 

--- a/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -136,7 +136,7 @@ public class MeterianClientAutofixFeatureTest {
         String[] gitConfigUserNameCommand = new String[] {
             "git",
             "config",
-            "--global",
+            "--local",
             "user.name",
             userName
         };
@@ -150,7 +150,7 @@ public class MeterianClientAutofixFeatureTest {
         String[] gitConfigUserEmailCommand = new String[] {
                 "git",
                 "config",
-                "--global",
+                "--local",
                 "user.email",
                 userEmail
         };

--- a/src/test/java/integration_tests/MeterianClientTest.java
+++ b/src/test/java/integration_tests/MeterianClientTest.java
@@ -46,7 +46,6 @@ public class MeterianClientTest {
     @Test
     public void givenConfiguration_whenMeterianClientIsRun_thenItShouldNotThrowException() throws IOException {
         // Given: we are setup to run the meterian client against a repo that has vulnerabilities
-
         EnvVars environment = getEnvironment();
         String meterianAPIToken = environment.get("METERIAN_API_TOKEN");
         assertThat("METERIAN_API_TOKEN has not been set, cannot run test without a valid value", meterianAPIToken, notNullValue());

--- a/src/test/java/integration_tests/MeterianClientTest.java
+++ b/src/test/java/integration_tests/MeterianClientTest.java
@@ -19,6 +19,8 @@ import io.meterian.jenkins.core.Meterian;
 import io.meterian.jenkins.glue.MeterianPlugin;
 import io.meterian.jenkins.io.ClientDownloader;
 import io.meterian.jenkins.io.HttpClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.*;


### PR DESCRIPTION
Happy path Autofix feature of the meterian client.

- Clones a vulnerable repo
- Runs scans against it
- Reports issues
- Fixes them
- Creates local branch, pushed to remote
- Creates Pull request from remote branch

Note: CI/CD needs access to push branch to remote GitHub i.e. https://github.com/MeterianHQ/autofix-sample-maven-upgrade, hence currently failing.