### PR TITLE
Fix 2 use cases of the autofix tests

### DIFF
--- a/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
@@ -43,6 +43,7 @@ public class AutoFixFeature {
         try {
             if (localGitClient.currentBranchHasNotBeenFixedYet()) {
                 if (failedClientExecution()) {
+                    localGitClient.resetChanges();
                     log.error(ABORTING_BRANCH_AND_PR_CREATION_PROCESS);
                     jenkinsLogger.println(ABORTING_BRANCH_AND_PR_CREATION_PROCESS);
                     return;

--- a/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
@@ -12,6 +12,8 @@ import java.io.PrintStream;
 
 public class AutoFixFeature {
 
+    private static final String ABORTING_BRANCH_AND_PR_CREATION_PROCESS = "[meterian] Aborting, not continuing with rest of the local/remote branch or pull request creation process.";
+
     private static final String LOCAL_BRANCH_ALREADY_EXISTS_WARNING =
             "[meterian] Warning: %s already exists in the local repo, skipping the local branch creation process";
 
@@ -40,16 +42,20 @@ public class AutoFixFeature {
     public void execute() {
         try {
             if (localGitClient.currentBranchHasNotBeenFixedYet()) {
-                clientRunner.execute();
+                if (failedClientExecution()) {
+                    log.error(ABORTING_BRANCH_AND_PR_CREATION_PROCESS);
+                    jenkinsLogger.println(ABORTING_BRANCH_AND_PR_CREATION_PROCESS);
+                    return;
+                }
             } else {
                 String fixedBranchExistsMessage = String.format(
-                                LOCAL_BRANCH_ALREADY_EXISTS_WARNING, localGitClient.getFixedBranchNameForCurrentBranch()
+                        LOCAL_BRANCH_ALREADY_EXISTS_WARNING, localGitClient.getFixedBranchNameForCurrentBranch()
                 );
                 log.warn(fixedBranchExistsMessage);
                 jenkinsLogger.println(fixedBranchExistsMessage);
             }
         } catch (Exception ex) {
-            log.error("Checking for branch or running the Meterian client was not successful due to: " + ex.getMessage(), ex);
+            log.error(String.format("Checking for branch or running the Meterian client was not successful due to: %s", ex.getMessage()), ex);
             throw new RuntimeException(ex);
         }
 
@@ -61,7 +67,7 @@ public class AutoFixFeature {
                 jenkinsLogger.println(LocalGitClient.NO_CHANGES_FOUND_WARNING);
             }
         } catch (Exception ex) {
-            log.error("Commits have not been applied due to the error: " + ex.getMessage(), ex);
+            log.error(String.format("Commits have not been applied due to the error: %s", ex.getMessage()), ex);
             throw new RuntimeException(ex);
         }
 
@@ -76,8 +82,12 @@ public class AutoFixFeature {
             );
             localGitHubClient.createPullRequest(localGitClient.getCurrentBranch());
         } catch (Exception ex) {
-            log.error("Pull Request was not created, due to the error: " + ex.getMessage(), ex);
+            log.error(String.format("Pull Request was not created, due to the error: %s", ex.getMessage()), ex);
             throw new RuntimeException(ex);
         }
+    }
+
+    private boolean failedClientExecution() {
+        return clientRunner.execute() != 0;
     }
 }

--- a/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -111,8 +111,6 @@ public class MeterianClientAutofixFeatureTest {
         // created onto the respective remote Github repository of the project
         verifyRunAnalysisLogs(logFile,
             new String[]{
-                "METERIAN_GITHUB_USER has not been set, tests will be run using the default value assumed for this environment variable",
-                "METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable",
                 "[meterian] Client successfully authorized",
                 "[meterian] Meterian Client v",
                 "[meterian] - autofix mode:      on",
@@ -152,8 +150,6 @@ public class MeterianClientAutofixFeatureTest {
         // with the fixes and also the pull request attached to this remote branch
         verifyRunAnalysisLogs(logFile,
             new String[]{
-                "METERIAN_GITHUB_USER has not been set, tests will be run using the default value assumed for this environment variable",
-                "METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable",
                 "[meterian] Client successfully authorized",
                 "[meterian] Meterian Client v",
                 "[meterian] - autofix mode:      on",
@@ -224,8 +220,6 @@ public class MeterianClientAutofixFeatureTest {
         // and NO pull request must be created onto the respective remote Github repository of the project
         verifyRunAnalysisLogs(logFile,
                 new String[]{
-                        "METERIAN_GITHUB_USER has not been set, tests will be run using the default value assumed for this environment variable",
-                        "METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable",
                         "[meterian] Client successfully authorized",
                         "[meterian] Meterian Client v",
                         "[meterian] - autofix mode:      on",

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -1,6 +1,5 @@
 package io.meterian.integration_tests;
 
-import hudson.EnvVars;
 import io.meterian.jenkins.autofixfeature.AutoFixFeature;
 import io.meterian.jenkins.autofixfeature.git.LocalGitClient;
 import io.meterian.jenkins.core.Meterian;
@@ -9,13 +8,17 @@ import io.meterian.jenkins.glue.clientrunners.ClientRunner;
 import io.meterian.jenkins.glue.executors.MeterianExecutor;
 import io.meterian.jenkins.glue.executors.StandardExecutor;
 import io.meterian.test_management.TestManagement;
+
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import hudson.EnvVars;
+
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
@@ -1,47 +1,64 @@
 package io.meterian.integration_tests;
 
-import hudson.EnvVars;
-import hudson.slaves.EnvironmentVariablesNodeProperty;
+import io.meterian.test_management.TestManagement;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.http.client.HttpClient;
+
 import org.junit.Before;
 import org.junit.Test;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Paths;
-import java.util.Map;
-
-import com.meterian.common.system.OS;
-import com.meterian.common.system.Shell;
-import io.meterian.jenkins.core.Meterian;
-import io.meterian.jenkins.glue.MeterianPlugin;
-import io.meterian.jenkins.io.ClientDownloader;
-import io.meterian.jenkins.io.HttpClientFactory;
-
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import hudson.EnvVars;
+
+import io.meterian.jenkins.core.Meterian;
+import io.meterian.jenkins.glue.MeterianPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class MeterianClientTest {
+
+    private static final Logger log = LoggerFactory.getLogger(MeterianClientTest.class);
 
     private static final String BASE_URL = "https://www.meterian.com";
     private static final String CURRENT_WORKING_DIR = System.getProperty("user.dir");
 
     private static final String NO_JVM_ARGS = "";
 
-    private String gitRepoWorkingFolder;
+    private TestManagement testManagement;
+    private File logFile;
+    private PrintStream jenkinsLogger;
+
+    private String githubProjectName = "autofix-sample-maven-upgrade";
+    private String gitRepoRootFolder = Paths.get(CURRENT_WORKING_DIR, "target/github-repo/").toString();
+    private String gitRepoWorkingFolder = Paths.get(gitRepoRootFolder, githubProjectName).toString();
+
     private EnvVars environment;
 
     @Before
     public void setup() throws IOException {
+        logFile = File.createTempFile("jenkins-logger-", Long.toString(System.nanoTime()));
+        jenkinsLogger = new PrintStream(logFile);
+        log.info("Jenkins log file: " + logFile.toPath().toString());
+
+        testManagement = new TestManagement(gitRepoWorkingFolder, log, jenkinsLogger);
+        environment = testManagement.getEnvironment();
+
         String gitRepoRootFolder = Paths.get(CURRENT_WORKING_DIR, "target/github-repo/").toString();
         FileUtils.deleteDirectory(new File(gitRepoRootFolder));
 
         new File(gitRepoRootFolder).mkdir();
 
-        gitRepoWorkingFolder = performCloneGitRepo("MeterianHQ", "autofix-sample-maven-upgrade", gitRepoRootFolder);
+        //gitRepoWorkingFolder =
+        testManagement.performCloneGitRepo(
+                "MeterianHQ",
+                "autofix-sample-maven-upgrade",
+                gitRepoRootFolder,
+                "master");
     }
 
     @Test
@@ -50,18 +67,17 @@ public class MeterianClientTest {
         PrintStream jenkinsLogger = new PrintStream(logFile);
 
         // Given: we are setup to run the meterian client against a repo that has vulnerabilities
-        environment = getEnvironment();
         String meterianAPIToken = environment.get("METERIAN_API_TOKEN");
         assertThat("METERIAN_API_TOKEN has not been set, cannot run test without a valid value", meterianAPIToken, notNullValue());
         String meterianGithubToken = environment.get("METERIAN_GITHUB_TOKEN");
         assertThat("METERIAN_GITHUB_TOKEN has not been set, cannot run test without a valid value", meterianGithubToken, notNullValue());
 
-        String meterianGithubUser = getMeterianGithubUser();
+        String meterianGithubUser = testManagement.getMeterianGithubUser();
         if ((meterianGithubUser == null) || meterianGithubUser.trim().isEmpty()) {
             jenkinsLogger.println("METERIAN_GITHUB_USER has not been set, tests will be run using the default value assumed for this environment variable");
         }
 
-        String meterianGithubEmail = getMeterianGithubEmail();
+        String meterianGithubEmail = testManagement.getMeterianGithubEmail();
         if ((meterianGithubEmail == null) || meterianGithubEmail.trim().isEmpty()) {
             jenkinsLogger.println("METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable");
         }
@@ -79,8 +95,8 @@ public class MeterianClientTest {
 
         // When: the meterian client is run against the locally cloned git repo
         try {
-            File clientJar = new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
-            Meterian client = Meterian.build(configuration, environment, jenkinsLogger, args, clientJar);
+            File clientJar = testManagement.getClientJar();
+            Meterian client = testManagement.getMeterianClient(configuration, clientJar);
             client.prepare("--interactive=false");
             client.run();
             jenkinsLogger.close();
@@ -89,93 +105,18 @@ public class MeterianClientTest {
         }
 
         // Then: we should be able to see the expecting output in the execution analysis output logs
-        String runAnalysisLogs = readRunAnalysisLogs(logFile.getPath());
-        assertThat(runAnalysisLogs, containsString("[meterian] Client successfully authorized"));
-        assertThat(runAnalysisLogs, containsString("[meterian] Meterian Client v"));
-        assertThat(runAnalysisLogs, containsString("[meterian] Project information:"));
-        assertThat(runAnalysisLogs, containsString("[meterian] JAVA scan -"));
-        assertThat(runAnalysisLogs, containsString("MeterianHQ/autofix-sample-maven-upgrade.git"));
-        assertThat(runAnalysisLogs, containsString("[meterian] Full report available at: "));
-        assertThat(runAnalysisLogs, containsString("[meterian] Build unsuccesful!"));
-        assertThat(runAnalysisLogs, containsString("[meterian] Failed checks: [security]"));
-    }
-
-    private String performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String gitRepoRootFolder) throws IOException {
-        String[] gitCloneRepoCommand = new String[] {
-                "git",
-                "clone",
-                String.format("git@github.com:%s/%s.git", githubOrgOrUserName, githubProjectName) // only use ssh or git protocol and not https - uses ssh keys to authenticate
-        };
-
-        Shell.Options options = new Shell.Options().
-                onDirectory(new File(gitRepoRootFolder));
-        Shell.Task task = new Shell().exec(
-                gitCloneRepoCommand,
-                options
+        testManagement.verifyRunAnalysisLogs(logFile,
+                new String[]{},
+                new String[]{
+                        "[meterian] Client successfully authorized",
+                        "[meterian] Meterian Client v",
+                        "[meterian] Project information:",
+                        "[meterian] JAVA scan -",
+                        "MeterianHQ/autofix-sample-maven-upgrade.git",
+                        "[meterian] Full report available at: ",
+                        "[meterian] Build unsuccesful!",
+                        "[meterian] Failed checks: [security]"
+                }
         );
-        task.waitFor();
-
-        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
-                task.exitValue(), task.exitValue(), is(equalTo(0)));
-
-        return Paths.get(gitRepoRootFolder, githubProjectName).toString();
-    }
-
-    private String readRunAnalysisLogs(String pathToLog) throws IOException {
-        File logFile = new File(pathToLog);
-        return FileUtils.readFileToString(logFile);
-    }
-
-    private PrintStream nullPrintStream() {
-        return new PrintStream(new NullOutputStream());
-    }
-
-    private static HttpClient newHttpClient() {
-        return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
-            @Override
-            public int getHttpConnectTimeout() {
-                return Integer.MAX_VALUE;
-            }
-
-            @Override
-            public int getHttpSocketTimeout() {
-                return Integer.MAX_VALUE;
-            }
-
-            @Override
-            public int getHttpMaxTotalConnections() {
-                return 100;
-            }
-
-            @Override
-            public int getHttpMaxDefaultConnectionsPerRoute() {
-                return 100;
-            }
-
-            @Override
-            public String getHttpUserAgent() {
-                // TODO Auto-generated method stub
-                return null;
-            }});
-    }
-
-    private EnvVars getEnvironment() {
-        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
-        EnvVars environment = prop.getEnvVars();
-
-        Map<String, String> localEnvironment = new OS().getenv();
-        for (String envKey: localEnvironment.keySet()) {
-            environment.put(envKey, localEnvironment.get(envKey));
-        }
-        environment.put("WORKSPACE", gitRepoWorkingFolder);
-        return environment;
-    }
-
-    private String getMeterianGithubUser() {
-        return environment.get("METERIAN_GITHUB_USER", "meterian-bot");
-    }
-
-    private String getMeterianGithubEmail() {
-        return environment.get("METERIAN_GITHUB_EMAIL", "bot.github@meterian.io");
     }
 }

--- a/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
@@ -1,4 +1,4 @@
-package integration_tests;
+package io.meterian.integration_tests;
 
 import hudson.EnvVars;
 import hudson.slaves.EnvironmentVariablesNodeProperty;

--- a/src/test/java/io/meterian/jenkins/io/ClientDownloaderTest.java
+++ b/src/test/java/io/meterian/jenkins/io/ClientDownloaderTest.java
@@ -1,29 +1,23 @@
 package io.meterian.jenkins.io;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
-import java.io.PrintStream;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.http.client.HttpClient;
-import org.junit.Before;
+import io.meterian.test_management.TestManagement;
 import org.junit.Test;
-
-import io.meterian.jenkins.io.ClientDownloader;
-import io.meterian.jenkins.io.HttpClientFactory;
 
 public class ClientDownloaderTest {
 
     private static final String BASE_URL = "https://www.meterian.com";
 
+    private TestManagement testManagement = new TestManagement();
+
     @Test
     public void shouldDownloadTheClientWhenTheHomeDirectoryIsNotFound() throws IOException {
         ClientDownloader.CACHE_FOLDER.delete();
 
-        new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+        new ClientDownloader(testManagement.newHttpClient(), BASE_URL, testManagement.nullPrintStream()).load();
 
         assertTrue(ClientDownloader.ETAG_FILE.exists());
         assertTrue(ClientDownloader.JAR_FILE.exists());
@@ -35,7 +29,7 @@ public class ClientDownloaderTest {
         ClientDownloader.JAR_FILE.createNewFile();
         ClientDownloader.ETAG_FILE.delete();
 
-        new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+        new ClientDownloader(testManagement.newHttpClient(), BASE_URL, testManagement.nullPrintStream()).load();
 
         assertTrue(ClientDownloader.ETAG_FILE.exists());
         assertTrue(ClientDownloader.JAR_FILE.exists());
@@ -47,42 +41,8 @@ public class ClientDownloaderTest {
         ClientDownloader.ETAG_FILE.createNewFile();
         ClientDownloader.JAR_FILE.delete();
         
-        new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+        new ClientDownloader(testManagement.newHttpClient(), BASE_URL, testManagement.nullPrintStream()).load();
         
         assertTrue(ClientDownloader.JAR_FILE.exists());
     }
- 
-    private PrintStream nullPrintStream() {
-        return new PrintStream(new NullOutputStream());
-    }
-
-    private static HttpClient newHttpClient() {
-        return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
-            @Override
-            public int getHttpConnectTimeout() {
-                return Integer.MAX_VALUE;
-            }
-
-            @Override
-            public int getHttpSocketTimeout() {
-                return Integer.MAX_VALUE;
-            }
-
-            @Override
-            public int getHttpMaxTotalConnections() {
-                return 100;
-            }
-
-            @Override
-            public int getHttpMaxDefaultConnectionsPerRoute() {
-                return 100;
-            }
-
-            @Override
-            public String getHttpUserAgent() {
-                // TODO Auto-generated method stub
-                return null;
-            }});
-    }
-
 }

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -46,7 +47,7 @@ public class TestManagement {
     public void verifyRunAnalysisLogs(File logFile,
                                       String[] containsLogLines,
                                       String[] doesNotContainLogLines) throws IOException {
-        String runAnalysisLogs = readRunAnalysisLogs(logFile.getPath());
+        String runAnalysisLogs = FileUtils.readFileToString(new File(logFile.getPath()));
 
         for (String eachLogLine: containsLogLines) {
             assertThat(runAnalysisLogs, containsString(eachLogLine));
@@ -102,7 +103,7 @@ public class TestManagement {
 
     }
 
-    public void performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) throws IOException {
+    public String performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) throws IOException {
         String[] gitCloneRepoCommand = new String[] {
                 "git",
                 "clone",
@@ -115,6 +116,8 @@ public class TestManagement {
 
         assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
                 exitCode, exitCode, is(equalTo(0)));
+
+        return Paths.get(workingFolder, githubProjectName).toString();
     }
 
     public String getMeterianGithubUser() {
@@ -164,11 +167,6 @@ public class TestManagement {
 
     public Meterian getMeterianClient(MeterianPlugin.Configuration configuration, File clientJar) throws IOException {
         return Meterian.build(configuration, environment, jenkinsLogger, NO_JVM_ARGS, clientJar);
-    }
-
-    private String readRunAnalysisLogs(String pathToLog) throws IOException {
-        File logFile = new File(pathToLog);
-        return FileUtils.readFileToString(logFile);
     }
 
     private EnvVars getOSEnvSettings() {

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -1,0 +1,233 @@
+package io.meterian.test_management;
+
+import com.meterian.common.system.LineGobbler;
+import com.meterian.common.system.OS;
+import com.meterian.common.system.Shell;
+import hudson.EnvVars;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import io.meterian.jenkins.core.Meterian;
+import io.meterian.jenkins.glue.MeterianPlugin;
+import io.meterian.jenkins.io.ClientDownloader;
+import io.meterian.jenkins.io.HttpClientFactory;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.http.client.HttpClient;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TestManagement {
+
+    private static final String BASE_URL = "https://www.meterian.com";
+    private static final String NO_JVM_ARGS = "";
+
+    private String gitRepoWorkingFolder;
+    private Logger log;
+    private PrintStream jenkinsLogger;
+    private EnvVars environment;
+
+    public TestManagement(String gitRepoWorkingFolder,
+                          Logger log,
+                          PrintStream jenkinsLogger) {
+        this.gitRepoWorkingFolder = gitRepoWorkingFolder;
+        this.log = log;
+        this.jenkinsLogger = jenkinsLogger;
+
+        environment = getEnvironment();
+    }
+
+    public void verifyRunAnalysisLogs(File logFile,
+                                      String[] containsLogLines,
+                                      String[] doesNotContainLogLines) throws IOException {
+        String runAnalysisLogs = readRunAnalysisLogs(logFile.getPath());
+
+        for (String eachLogLine: containsLogLines) {
+            assertThat(runAnalysisLogs, containsString(eachLogLine));
+        }
+
+        for (String eachLogLine: doesNotContainLogLines) {
+            assertThat(runAnalysisLogs, not(containsString(eachLogLine)));
+        }
+    }
+
+    public void configureGitUserNameAndEmail(String userName, String userEmail) throws IOException {
+        // git config --global user.name "Your Name"
+        String[] gitConfigUserNameCommand = new String[] {
+                "git",
+                "config",
+                "--local",
+                "user.name",
+                userName
+        };
+
+        int exitCode = runCommand(gitConfigUserNameCommand, gitRepoWorkingFolder, log);
+
+        assertThat("Cannot run the test, as we were unable configure a user due to error code: " +
+                exitCode, exitCode, is(equalTo(0)));
+
+        // git config --global user.email "you@example.com"
+        String[] gitConfigUserEmailCommand = new String[] {
+                "git",
+                "config",
+                "--local",
+                "user.email",
+                userEmail
+        };
+
+        exitCode = runCommand(gitConfigUserEmailCommand, gitRepoWorkingFolder, log);
+
+        assertThat("Cannot run the test, as we were unable configure a user userEmail due to error code: " +
+                exitCode, exitCode, is(equalTo(0)));
+    }
+
+    public void deleteRemoteBranch(String branchName) throws IOException {
+        String[] gitCloneRepoCommand = new String[] {
+                "git",
+                "push",
+                "origin",
+                ":" + branchName
+        };
+
+        int exitCode = runCommand(gitCloneRepoCommand, gitRepoWorkingFolder, log);
+
+        assertThat("Cannot run the test, as we were unable to remove a remote branch from a repo due to error code: " +
+                exitCode, exitCode, is(equalTo(0)));
+
+    }
+
+    public void performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) throws IOException {
+        String[] gitCloneRepoCommand = new String[] {
+                "git",
+                "clone",
+                String.format("git@github.com:%s/%s.git", githubOrgOrUserName, githubProjectName), // only use ssh or git protocol and not https - uses ssh keys to authenticate
+                "-b",
+                branch
+        };
+
+        int exitCode = runCommand(gitCloneRepoCommand, workingFolder, log);
+
+        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
+                exitCode, exitCode, is(equalTo(0)));
+    }
+
+    public String getMeterianGithubUser() {
+        return getOSEnvSettings().get("METERIAN_GITHUB_USER");
+    }
+
+    public String getMeterianGithubEmail() {
+        return getOSEnvSettings().get("METERIAN_GITHUB_EMAIL");
+    }
+
+    public EnvVars getEnvironment() {
+        EnvVars environment = getOSEnvSettings();
+        environment.put("WORKSPACE", gitRepoWorkingFolder);
+        return environment;
+    }
+
+    public MeterianPlugin.Configuration getConfiguration() {
+        String meterianAPIToken = environment.get("METERIAN_API_TOKEN");
+        assertThat("METERIAN_API_TOKEN has not been set, cannot run test without a valid value", meterianAPIToken, notNullValue());
+
+        String meterianGithubUser = getMeterianGithubUser();
+        if ((meterianGithubUser == null) || meterianGithubUser.trim().isEmpty()) {
+            jenkinsLogger.println("METERIAN_GITHUB_USER has not been set, tests will be run using the default value assumed for this environment variable");
+        }
+
+        String meterianGithubEmail = getMeterianGithubEmail();
+        if ((meterianGithubEmail == null) || meterianGithubEmail.trim().isEmpty()) {
+            jenkinsLogger.println("METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable");
+        }
+
+        String meterianGithubToken = environment.get("METERIAN_GITHUB_TOKEN");
+        assertThat("METERIAN_GITHUB_TOKEN has not been set, cannot run test without a valid value", meterianGithubToken, notNullValue());
+
+        return new MeterianPlugin.Configuration(
+                BASE_URL,
+                meterianAPIToken,
+                NO_JVM_ARGS,
+                meterianGithubUser,
+                meterianGithubEmail,
+                meterianGithubToken
+        );
+    }
+
+    public File getClientJar() throws IOException {
+        return new ClientDownloader(newHttpClient(), BASE_URL, nullPrintStream()).load();
+    }
+
+    public Meterian getMeterianClient(MeterianPlugin.Configuration configuration, File clientJar) throws IOException {
+        return Meterian.build(configuration, environment, jenkinsLogger, NO_JVM_ARGS, clientJar);
+    }
+
+    private String readRunAnalysisLogs(String pathToLog) throws IOException {
+        File logFile = new File(pathToLog);
+        return FileUtils.readFileToString(logFile);
+    }
+
+    private EnvVars getOSEnvSettings() {
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars environment = prop.getEnvVars();
+
+        Map<String, String> localEnvironment = new OS().getenv();
+        for (String envKey: localEnvironment.keySet()) {
+            environment.put(envKey, localEnvironment.get(envKey));
+        }
+        return environment;
+    }
+
+    private int runCommand(String[] command, String workingFolder, Logger log) throws IOException {
+        LineGobbler errorLineGobbler = (type, text) ->
+                log.error("{}> {}", type, text);
+
+        Shell.Options options = new Shell.Options()
+                .onDirectory(new File(workingFolder))
+                .withErrorGobbler(errorLineGobbler)
+                .withEnvironmentVariables(getOSEnvSettings());
+        Shell.Task task = new Shell().exec(
+                command,
+                options
+        );
+
+        return task.waitFor();
+    }
+
+    private PrintStream nullPrintStream() {
+        return new PrintStream(new NullOutputStream());
+    }
+
+    private static HttpClient newHttpClient() {
+        return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
+            @Override
+            public int getHttpConnectTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpSocketTimeout() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public int getHttpMaxTotalConnections() {
+                return 100;
+            }
+
+            @Override
+            public int getHttpMaxDefaultConnectionsPerRoute() {
+                return 100;
+            }
+
+            @Override
+            public String getHttpUserAgent() {
+                // TODO Auto-generated method stub
+                return null;
+            }});
+    }
+}

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -44,6 +44,8 @@ public class TestManagement {
         environment = getEnvironment();
     }
 
+    public TestManagement() {}
+
     public void verifyRunAnalysisLogs(File logFile,
                                       String[] containsLogLines,
                                       String[] doesNotContainLogLines) throws IOException {
@@ -196,11 +198,11 @@ public class TestManagement {
         return task.waitFor();
     }
 
-    private PrintStream nullPrintStream() {
+    public PrintStream nullPrintStream() {
         return new PrintStream(new NullOutputStream());
     }
 
-    private static HttpClient newHttpClient() {
+    public static HttpClient newHttpClient() {
         return new HttpClientFactory().newHttpClient(new HttpClientFactory.Config() {
             @Override
             public int getHttpConnectTimeout() {


### PR DESCRIPTION
Add the following tests:

- happy path ensuring checking if meterian client returns zero exit code (uses latest fix to master on sample project)
- edge case ensuring checking if meterian client returns non-zero exit code (uses old partially fixed branch on sample project)

Refactored all tests and removed duplicates, move test supporting functionality into its own class.

This also helps resolve answers to question #27, fixes #7, fixes #8, fixes #9 and fixes #10